### PR TITLE
Edit user crontab using crontab-mode

### DIFF
--- a/crontab-mode.el
+++ b/crontab-mode.el
@@ -158,8 +158,7 @@ The crontab can be edited and then installed again by calling
 `crontab-install-user-crontab'.  The buffer does not need to be
 saved since no file is associated with it.
 
-The operating system must provide the `crontab(1)' command to read
-the crontab."
+The `crontab(1)' executable is used to load the crontab."
   (interactive)
   (let ((buffer (get-buffer-create "*crontab*")))
     (switch-to-buffer buffer)

--- a/crontab-mode.el
+++ b/crontab-mode.el
@@ -169,7 +169,8 @@ The `crontab(1)' executable is used to load the crontab."
         (error "Loading crontab failed"))
       (erase-buffer)
       (insert "# crontab\n"))
-    (goto-char (point-max))
+    (set-buffer-modified-p nil)
+    (goto-char (point-min))
     (crontab-mode)
     (setq-local crontab-user-crontab-file t)))
 

--- a/crontab-mode.el
+++ b/crontab-mode.el
@@ -165,7 +165,7 @@ The `crontab(1)' executable is used to load the crontab."
     (erase-buffer)
     (when (> (call-process "crontab" nil t nil "-l") 0)
       (goto-char (point-min))
-      (unless (looking-at (concat "^crontab: no crontab for " user-login-name))
+      (unless (looking-at "^crontab: no crontab")
         (error "Loading crontab failed"))
       (erase-buffer)
       (insert "# crontab\n"))

--- a/crontab-mode.el
+++ b/crontab-mode.el
@@ -190,9 +190,9 @@ The `crontab(1)' executable is used to save the crontab."
   (if crontab-user-crontab-file
       (save-restriction
         (widen)
-        (goto-char (point-max))
         ;; Insert newline if missing on last line
-        (unless (and (> (point) 1) (looking-back "\n" (1- (point))))
+        (unless (eq (char-before (point-max)) ?\n)
+          (goto-char (point-max))
           (insert "\n"))
         (if (> (call-process-region nil nil "crontab") 0)
             (error "Installing crontab failed")

--- a/crontab-mode.el
+++ b/crontab-mode.el
@@ -152,6 +152,55 @@
       (setcar (nthcdr n fields) (propertize (elt fields n) 'face 'font-lock-constant-face)))
     (mapconcat 'identity fields "  ")))
 
+(defun crontab-edit-user-crontab ()
+  "Create a buffer to edit the user crontab.
+The crontab can be edited and then installed again by calling
+`crontab-install-user-crontab'.  The buffer does not need to be
+saved since no file is associated with it.
+
+The operating system must provide the `crontab(1)' command to read
+the crontab."
+  (interactive)
+  (let ((buffer (get-buffer-create "*crontab*")))
+    (switch-to-buffer buffer)
+    (erase-buffer)
+    (when (> (call-process "crontab" nil t nil "-l") 0)
+      (goto-char (point-min))
+      (unless (looking-at (concat "^crontab: no crontab for " user-login-name))
+        (error "Loading crontab failed"))
+      (erase-buffer)
+      (insert "# crontab\n"))
+    (goto-char (point-max))
+    (crontab-mode)
+    (setq-local crontab-user-crontab-file t)))
+
+(defun crontab-install-user-crontab ()
+  "Install the contents of the current buffer as user crontab.
+An error will be signaled if the buffer hasn't been created by
+`crontab-edit-user-crontab'.  If the user crontab already exists,
+it will be replaced without any further confirmation.
+
+If the last line does not end with a newline character, then it
+will be added before the crontab is installed.
+
+The buffer can be saved to a file for your own reference but that
+is not required for installing the crontab.
+
+The `crontab(1)' executable is used to save the crontab."
+  (interactive)
+  (if crontab-user-crontab-file
+      (save-restriction
+        (widen)
+        (goto-char (point-max))
+        ;; Insert newline if missing on last line
+        (unless (and (> (point) 1) (looking-back "\n" (1- (point))))
+          (insert "\n"))
+        (if (> (call-process-region nil nil "crontab") 0)
+            (error "Installing crontab failed")
+          (kill-buffer)
+          (message "Installed crontab")))
+    (error "Only a user crontab can be installed")))
+
 ;;;###autoload
 (define-derived-mode crontab-mode text-mode "Crontab"
   "Major mode for editing crontab file.
@@ -171,7 +220,13 @@
        '(crontab-font-lock-keywords nil t))
 
   (set (make-local-variable 'indent-line-function)
-       'crontab-indent-line))
+       'crontab-indent-line)
+
+  ;; Set to t by `crontab-edit-user-crontab' when editing a user crontab
+  (set (make-local-variable 'crontab-user-crontab-file)
+       nil)
+
+  (define-key crontab-mode-map (kbd "C-c C-c") #'crontab-install-user-crontab))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("/crontab\\(\\.X*[[:alnum:]]+\\)?\\'" . crontab-mode))


### PR DESCRIPTION
The function `crontab-edit-user-crontab` opens the user's crontab in an Emacs buffer using `crontab-mode`.  After editing the crontab can be installed again using the `crontab-install-user-crontab` function (bound to "C-c C-c" by default).

The operating system command crontab(1) is used the load and save the user's crontab.

With these functions it is now possible to edit the user's crontab without leaving Emacs.